### PR TITLE
fix: Bundle React frontend in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Node.js
+        if: steps.check_release.outputs.exists == 'false'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Build frontend
+        if: steps.check_release.outputs.exists == 'false'
+        run: cd frontend && npm ci && npm run build
+
+      - name: Bundle frontend into package
+        if: steps.check_release.outputs.exists == 'false'
+        run: cp -r frontend/dist src/legacylipi/api/static
+
       - name: Build package
         if: steps.check_release.outputs.exists == 'false'
         run: uv build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "legacylipi"
-version = "1.0.1"
+version = "1.0.2"
 description = "Legacy Font PDF Translator - Translate PDFs with legacy Indian font encodings to English"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -671,7 +671,7 @@ wheels = [
 
 [[package]]
 name = "legacylipi"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Release workflow was missing Node.js build steps — PyPI package had no frontend static files
- Added `setup-node`, `npm ci && npm run build`, and `cp -r frontend/dist src/legacylipi/api/static` before `uv build`
- Matches the existing CI build job pattern
- Bumps version to 1.0.2

## Root cause
`uvx legacylipi api` returned `404 Not Found` on `/` because the wheel had no `static/` directory

## Test plan
- [ ] CI passes (test + build jobs)
- [ ] After merge, `uvx legacylipi api` serves the React UI at `http://localhost:8000/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)